### PR TITLE
Sunxi 6.1 / 6.2: h616 (OrangePi Zero 2): Add CPU frequency scaling

### DIFF
--- a/patch/kernel/archive/sunxi-6.1/patches.armbian/arm64-dts-allwinner-h616-cpu-optimizations.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.armbian/arm64-dts-allwinner-h616-cpu-optimizations.patch
@@ -1,0 +1,313 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20Dzieko=C5=84ski?=
+ <michal.dziekonski+github@gmail.com>
+Date: Thu, 22 May 2023 19:11:15 +0000
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Subject: h616: cpu frequency optimizations
+
+Based on patches by AGM1968 <AGM1968@users.noreply.github.com> for 5.19 kernel
+
+Signed-off-by: Michał Dziekoński <michal.dziekonski+github@gmail.com>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts | 94 ++++++++++
+ drivers/cpufreq/cpufreq-dt-platdev.c                         |  1 +
+ drivers/cpufreq/sun50i-cpufreq-nvmem.c                       | 87 ++++++---
+ 3 files changed, 158 insertions(+), 24 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts b/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
+index b78941d29..6739296d1 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
+@@ -58,10 +58,69 @@ reg_usb1_vbus: usb1-vbus {
+ 		vin-supply = <&reg_vcc5v>;
+ 		enable-active-high;
+ 		gpio = <&pio 2 16 GPIO_ACTIVE_HIGH>; /* PC16 */
+ 		status = "okay";
+ 	};
++
++	cpu_opp_table: opp-table-cpu {
++		compatible = "allwinner,sun50i-h616-operating-points";
++		nvmem-cells = <&cpu_speed_grade>;
++		opp-shared;
++
++		opp-480000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <480000000>;
++
++			opp-microvolt-speed0 = <820000 820000 1100000>;
++			opp-microvolt-speed1 = <880000 880000 1100000>;
++			opp-microvolt-speed2 = <880000 880000 1100000>;
++		};
++
++		opp-600000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <600000000>;
++
++			opp-microvolt-speed0 = <820000 820000 1100000>;
++			opp-microvolt-speed1 = <880000 880000 1100000>;
++			opp-microvolt-speed2 = <880000 880000 1100000>;
++		};
++
++		opp-792000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <792000000>;
++		        opp-microvolt-speed0 = <860000 860000 1100000>;
++			opp-microvolt-speed1 = <940000 940000 1100000>;
++			opp-microvolt-speed2 = <940000 940000 1100000>;
++		};
++
++		opp-1008000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <1008000000>;
++
++			opp-microvolt-speed0 = <900000 900000 1100000>;
++			opp-microvolt-speed1 = <1020000 1020000 1100000>;
++			opp-microvolt-speed2 = <1020000 1020000 1100000>;
++		};
++
++		opp-1200000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <1200000000>;
++
++			opp-microvolt-speed0 = <960000 960000 1100000>;
++			opp-microvolt-speed1 = <1100000 1100000 1100000>;
++			opp-microvolt-speed2 = <1100000 1100000 1100000>;
++		};
++
++		opp-1512000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <1512000000>;
++
++			opp-microvolt-speed0 = <1100000 1100000 1100000>;
++			opp-microvolt-speed1 = <1100000 1100000 1100000>;
++			opp-microvolt-speed2 = <1100000 1100000 1100000>;
++		};
++	};
+ };
+ 
+ &ehci1 {
+ 	status = "okay";
+ };
+@@ -214,10 +289,25 @@ &pio {
+ 	vcc-pg-supply = <&reg_bldo1>;
+ 	vcc-ph-supply = <&reg_aldo1>;
+ 	vcc-pi-supply = <&reg_aldo1>;
+ };
+ 
++&cpu0 {
++	cpu-supply = <&reg_dcdca>;
++	status = "okay";
++	operating-points-v2 = <&cpu_opp_table>;
++};
++&cpu1 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++&cpu2 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++&cpu3 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
+ &spi0  {
+ 	status = "okay";
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&spi0_pins>, <&spi0_cs0_pin>;
+ 
+diff --git a/drivers/cpufreq/cpufreq-dt-platdev.c b/drivers/cpufreq/cpufreq-dt-platdev.c
+index 69a8742c0..f20d412ef 100644
+--- a/drivers/cpufreq/cpufreq-dt-platdev.c
++++ b/drivers/cpufreq/cpufreq-dt-platdev.c
+@@ -100,10 +100,11 @@ static const struct of_device_id allowlist[] __initconst = {
+  * Machines for which the cpufreq device is *not* created, mostly used for
+  * platforms using "operating-points-v2" property.
+  */
+ static const struct of_device_id blocklist[] __initconst = {
+ 	{ .compatible = "allwinner,sun50i-h6", },
++	{ .compatible = "allwinner,sun50i-h616", },
+ 
+ 	{ .compatible = "arm,vexpress", },
+ 
+ 	{ .compatible = "calxeda,highbank", },
+ 	{ .compatible = "calxeda,ecx-2000", },
+diff --git a/drivers/cpufreq/sun50i-cpufreq-nvmem.c b/drivers/cpufreq/sun50i-cpufreq-nvmem.c
+index 1acec58c3..dded3fe81 100644
+--- a/drivers/cpufreq/sun50i-cpufreq-nvmem.c
++++ b/drivers/cpufreq/sun50i-cpufreq-nvmem.c
+@@ -17,41 +17,77 @@
+ #include <linux/pm_opp.h>
+ #include <linux/slab.h>
+ 
+ #define MAX_NAME_LEN	7
+ 
+-#define NVMEM_MASK	0x7
+-#define NVMEM_SHIFT	5
++#define SUN50I_H616_NVMEM_MASK 0x22
++#define SUN50I_H616_NVMEM_SHIFT 5
++#define SUN50I_H6_NVMEM_MASK 0x7
++#define SUN50I_H6_NVMEM_SHIFT 5
++
++struct sunxi_cpufreq_soc_data {
++	u32 (*efuse_xlate) (void *efuse);
++};
+ 
+ static struct platform_device *cpufreq_dt_pdev, *sun50i_cpufreq_pdev;
+ 
++static u32 sun50i_h616_efuse_xlate(void *efuse)
++{
++	u32 efuse_value = (*(u32 *)efuse >> SUN50I_H616_NVMEM_SHIFT) &
++		SUN50I_H616_NVMEM_MASK;
++
++	/* Tested as h616 soc. Expected efuse values are 1 -3,
++	slowest to fastest */
++	if (efuse_value >=1 && efuse_value <= 3)
++		return efuse_value - 1;
++	else
++		return 0;
++};
++
++static u32 sun50i_h6_efuse_xlate(void *efuse)
++{
++	u32 efuse_value = (*(u32 *)efuse >> SUN50I_H6_NVMEM_SHIFT) &
++		SUN50I_H6_NVMEM_MASK;
++
++	/*
++	* We treat unexpected efuse values as if the SoC was from
++	* the slowest bin. Expected efuse values are 1 -3, slowest
++	* to fastest.
++	*/
++	if (efuse_value >= 1 && efuse_value <= 3)
++		return efuse_value - 1;
++	else
++		return 0;
++};
++
+ /**
+  * sun50i_cpufreq_get_efuse() - Determine speed grade from efuse value
++ * @soc_data: pointer to sunxi_cpufreq_soc_data context
+  * @versions: Set to the value parsed from efuse
+  *
+  * Returns 0 if success.
+  */
+-static int sun50i_cpufreq_get_efuse(u32 *versions)
++static int sun50i_cpufreq_get_efuse(const struct sunxi_cpufreq_soc_data *soc_data,
++	u32 *versions)
+ {
+ 	struct nvmem_cell *speedbin_nvmem;
+ 	struct device_node *np;
+ 	struct device *cpu_dev;
+-	u32 *speedbin, efuse_value;
++	u32 *speedbin;
+ 	size_t len;
+-	int ret;
+ 
+ 	cpu_dev = get_cpu_device(0);
+ 	if (!cpu_dev)
+ 		return -ENODEV;
+ 
+ 	np = dev_pm_opp_of_get_opp_desc_node(cpu_dev);
+ 	if (!np)
+ 		return -ENOENT;
+ 
+-	ret = of_device_is_compatible(np,
+-				      "allwinner,sun50i-h6-operating-points");
+-	if (!ret) {
++	if      (of_device_is_compatible(np, "allwinner,sun50i-h6-operating-points")) {}
++	else if	(of_device_is_compatible(np, "allwinner,sun50i-h616-operating-points")) {}
++	else {
+ 		of_node_put(np);
+ 		return -ENOENT;
+ 	}
+ 
+ 	speedbin_nvmem = of_nvmem_cell_get(np, NULL);
+@@ -63,40 +99,35 @@ static int sun50i_cpufreq_get_efuse(u32 *versions)
+ 	speedbin = nvmem_cell_read(speedbin_nvmem, &len);
+ 	nvmem_cell_put(speedbin_nvmem);
+ 	if (IS_ERR(speedbin))
+ 		return PTR_ERR(speedbin);
+ 
+-	efuse_value = (*speedbin >> NVMEM_SHIFT) & NVMEM_MASK;
+-
+-	/*
+-	 * We treat unexpected efuse values as if the SoC was from
+-	 * the slowest bin. Expected efuse values are 1-3, slowest
+-	 * to fastest.
+-	 */
+-	if (efuse_value >= 1 && efuse_value <= 3)
+-		*versions = efuse_value - 1;
+-	else
+-		*versions = 0;
++	*versions = soc_data->efuse_xlate(speedbin);
+ 
+ 	kfree(speedbin);
+ 	return 0;
+ };
+ 
+ static int sun50i_cpufreq_nvmem_probe(struct platform_device *pdev)
+ {
++	const struct of_device_id *match;
+ 	int *opp_tokens;
+ 	char name[MAX_NAME_LEN];
+ 	unsigned int cpu;
+ 	u32 speed = 0;
+ 	int ret;
+ 
++	match = dev_get_platdata(&pdev->dev);
++	if (!match)
++		return -EINVAL;
++
+ 	opp_tokens = kcalloc(num_possible_cpus(), sizeof(*opp_tokens),
+ 			     GFP_KERNEL);
+ 	if (!opp_tokens)
+ 		return -ENOMEM;
+ 
+-	ret = sun50i_cpufreq_get_efuse(&speed);
++	ret = sun50i_cpufreq_get_efuse(match->data, &speed);
+ 	if (ret) {
+ 		kfree(opp_tokens);
+ 		return ret;
+ 	}
+ 
+@@ -158,12 +189,20 @@ static struct platform_driver sun50i_cpufreq_driver = {
+ 	.driver = {
+ 		.name = "sun50i-cpufreq-nvmem",
+ 	},
+ };
+ 
++static const struct sunxi_cpufreq_soc_data sun50i_h616_data = {
++	.efuse_xlate = sun50i_h616_efuse_xlate,
++};
++static const struct sunxi_cpufreq_soc_data sun50i_h6_data = {
++	.efuse_xlate = sun50i_h6_efuse_xlate,
++};
++
+ static const struct of_device_id sun50i_cpufreq_match_list[] = {
+-	{ .compatible = "allwinner,sun50i-h6" },
++	{ .compatible = "allwinner,sun50i-h6", .data = &sun50i_h6_data },
++	{ .compatible = "allwinner,sun50i-h616", .data = &sun50i_h616_data },
+ 	{}
+ };
+ MODULE_DEVICE_TABLE(of, sun50i_cpufreq_match_list);
+ 
+ static const struct of_device_id *sun50i_cpufreq_match_node(void)
+@@ -194,13 +233,13 @@ static int __init sun50i_cpufreq_init(void)
+ 
+ 	ret = platform_driver_register(&sun50i_cpufreq_driver);
+ 	if (unlikely(ret < 0))
+ 		return ret;
+ 
+-	sun50i_cpufreq_pdev =
+-		platform_device_register_simple("sun50i-cpufreq-nvmem",
+-						-1, NULL, 0);
++	sun50i_cpufreq_pdev = platform_device_register_data(NULL,
++		"sun50i-cpufreq-nvmem", -1, match, sizeof(*match));
++
+ 	ret = PTR_ERR_OR_ZERO(sun50i_cpufreq_pdev);
+ 	if (ret == 0)
+ 		return 0;
+ 
+ 	platform_driver_unregister(&sun50i_cpufreq_driver);
+-- 
+Created with Armbian build tools https://github.com/armbian/build

--- a/patch/kernel/archive/sunxi-6.1/series.armbian
+++ b/patch/kernel/archive/sunxi-6.1/series.armbian
@@ -90,6 +90,7 @@
 	patches.armbian/arm64-dts-allwinner-h616-Add-device-node-for-SID.patch
 	patches.armbian/arm64-dts-allwinner-h616-Add-thermal-sensor-and-thermal-zones.patch
 	patches.armbian/arm64-dts-allwinner-h616-Fix-thermal-zones-missing-trips.patch
+	patches.armbian/arm64-dts-allwinner-h616-cpu-optimizations.patch
 ###################
 	patches.armbian/arm64-dts-sun50i-a64-pinebook-enable-Bluetooth.patch
 	patches.armbian/arm64-dts-sun50i-a64-pine64-enable-Bluetooth.patch

--- a/patch/kernel/archive/sunxi-6.1/series.conf
+++ b/patch/kernel/archive/sunxi-6.1/series.conf
@@ -494,6 +494,7 @@
 	patches.armbian/arm64-dts-allwinner-h616-Add-device-node-for-SID.patch
 	patches.armbian/arm64-dts-allwinner-h616-Add-thermal-sensor-and-thermal-zones.patch
 	patches.armbian/arm64-dts-allwinner-h616-Fix-thermal-zones-missing-trips.patch
+	patches.armbian/arm64-dts-allwinner-h616-cpu-optimizations.patch
 ###################
 	patches.armbian/arm64-dts-sun50i-a64-pinebook-enable-Bluetooth.patch
 	patches.armbian/arm64-dts-sun50i-a64-pine64-enable-Bluetooth.patch

--- a/patch/kernel/archive/sunxi-6.2/patches.armbian/arm64-dts-allwinner-h616-cpu-optimizations.patch
+++ b/patch/kernel/archive/sunxi-6.2/patches.armbian/arm64-dts-allwinner-h616-cpu-optimizations.patch
@@ -1,0 +1,314 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20Dzieko=C5=84ski?=
+ <michal.dziekonski+github@gmail.com>
+Date: Thu, 4 May 2023 18:29:15 +0000
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Subject: h616: cpu optimizations (opp table added)
+
+Based on patches by AGM1968 <AGM1968@users.noreply.github.com> for 5.19 kernel
+
+Signed-off-by: Michał Dziekoński <michal.dziekonski+github@gmail.com>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts | 74 ++++++++
+ drivers/cpufreq/cpufreq-dt-platdev.c                         |  1 +
+ drivers/cpufreq/sun50i-cpufreq-nvmem.c                       | 87 +++++++---
+ 3 files changed, 138 insertions(+), 24 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts b/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
+index 97d84e05a..22ef7cbe1 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
+@@ -58,10 +58,69 @@ reg_usb1_vbus: regulator-usb1-vbus {
+ 		vin-supply = <&reg_vcc5v>;
+ 		enable-active-high;
+ 		gpio = <&pio 2 16 GPIO_ACTIVE_HIGH>; /* PC16 */
+ 		status = "okay";
+ 	};
++
++	cpu_opp_table: opp-table-cpu {
++		compatible = "allwinner,sun50i-h616-operating-points";
++		nvmem-cells = <&cpu_speed_grade>;
++		opp-shared;
++
++		opp-480000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <480000000>;
++
++			opp-microvolt-speed0 = <820000 820000 1100000>;
++			opp-microvolt-speed1 = <880000 880000 1100000>;
++			opp-microvolt-speed2 = <880000 880000 1100000>;
++		};
++
++		opp-600000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <600000000>;
++
++			opp-microvolt-speed0 = <820000 820000 1100000>;
++			opp-microvolt-speed1 = <880000 880000 1100000>;
++			opp-microvolt-speed2 = <880000 880000 1100000>;
++		};
++
++		opp-792000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <792000000>;
++		        opp-microvolt-speed0 = <860000 860000 1100000>;
++			opp-microvolt-speed1 = <940000 940000 1100000>;
++			opp-microvolt-speed2 = <940000 940000 1100000>;
++		};
++
++		opp-1008000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <1008000000>;
++
++			opp-microvolt-speed0 = <900000 900000 1100000>;
++			opp-microvolt-speed1 = <1020000 1020000 1100000>;
++			opp-microvolt-speed2 = <1020000 1020000 1100000>;
++		};
++
++		opp-1200000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <1200000000>;
++
++			opp-microvolt-speed0 = <960000 960000 1100000>;
++			opp-microvolt-speed1 = <1100000 1100000 1100000>;
++			opp-microvolt-speed2 = <1100000 1100000 1100000>;
++		};
++
++		opp-1512000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <1512000000>;
++
++			opp-microvolt-speed0 = <1100000 1100000 1100000>;
++			opp-microvolt-speed1 = <1100000 1100000 1100000>;
++			opp-microvolt-speed2 = <1100000 1100000 1100000>;
++		};
++	};
+ };
+ 
+ &ehci1 {
+ 	status = "okay";
+ };
+@@ -220,10 +279,25 @@ &pio {
+ 	vcc-pg-supply = <&reg_bldo1>;
+ 	vcc-ph-supply = <&reg_aldo1>;
+ 	vcc-pi-supply = <&reg_aldo1>;
+ };
+ 
++&cpu0 {
++	cpu-supply = <&reg_dcdca>;
++	status = "okay";
++	operating-points-v2 = <&cpu_opp_table>;
++};
++&cpu1 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++&cpu2 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++&cpu3 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
+ &spi0  {
+ 	status = "okay";
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&spi0_pins>, <&spi0_cs0_pin>;
+ 
+diff --git a/drivers/cpufreq/cpufreq-dt-platdev.c b/drivers/cpufreq/cpufreq-dt-platdev.c
+index e85703651..e4fa483c8 100644
+--- a/drivers/cpufreq/cpufreq-dt-platdev.c
++++ b/drivers/cpufreq/cpufreq-dt-platdev.c
+@@ -100,10 +100,11 @@ static const struct of_device_id allowlist[] __initconst = {
+  * Machines for which the cpufreq device is *not* created, mostly used for
+  * platforms using "operating-points-v2" property.
+  */
+ static const struct of_device_id blocklist[] __initconst = {
+ 	{ .compatible = "allwinner,sun50i-h6", },
++	{ .compatible = "allwinner,sun50i-h616", },
+ 
+ 	{ .compatible = "apple,arm-platform", },
+ 
+ 	{ .compatible = "arm,vexpress", },
+ 
+diff --git a/drivers/cpufreq/sun50i-cpufreq-nvmem.c b/drivers/cpufreq/sun50i-cpufreq-nvmem.c
+index 1acec58c3..dded3fe81 100644
+--- a/drivers/cpufreq/sun50i-cpufreq-nvmem.c
++++ b/drivers/cpufreq/sun50i-cpufreq-nvmem.c
+@@ -17,41 +17,77 @@
+ #include <linux/pm_opp.h>
+ #include <linux/slab.h>
+ 
+ #define MAX_NAME_LEN	7
+ 
+-#define NVMEM_MASK	0x7
+-#define NVMEM_SHIFT	5
++#define SUN50I_H616_NVMEM_MASK 0x22
++#define SUN50I_H616_NVMEM_SHIFT 5
++#define SUN50I_H6_NVMEM_MASK 0x7
++#define SUN50I_H6_NVMEM_SHIFT 5
++
++struct sunxi_cpufreq_soc_data {
++	u32 (*efuse_xlate) (void *efuse);
++};
+ 
+ static struct platform_device *cpufreq_dt_pdev, *sun50i_cpufreq_pdev;
+ 
++static u32 sun50i_h616_efuse_xlate(void *efuse)
++{
++	u32 efuse_value = (*(u32 *)efuse >> SUN50I_H616_NVMEM_SHIFT) &
++		SUN50I_H616_NVMEM_MASK;
++
++	/* Tested as h616 soc. Expected efuse values are 1 -3,
++	slowest to fastest */
++	if (efuse_value >=1 && efuse_value <= 3)
++		return efuse_value - 1;
++	else
++		return 0;
++};
++
++static u32 sun50i_h6_efuse_xlate(void *efuse)
++{
++	u32 efuse_value = (*(u32 *)efuse >> SUN50I_H6_NVMEM_SHIFT) &
++		SUN50I_H6_NVMEM_MASK;
++
++	/*
++	* We treat unexpected efuse values as if the SoC was from
++	* the slowest bin. Expected efuse values are 1 -3, slowest
++	* to fastest.
++	*/
++	if (efuse_value >= 1 && efuse_value <= 3)
++		return efuse_value - 1;
++	else
++		return 0;
++};
++
+ /**
+  * sun50i_cpufreq_get_efuse() - Determine speed grade from efuse value
++ * @soc_data: pointer to sunxi_cpufreq_soc_data context
+  * @versions: Set to the value parsed from efuse
+  *
+  * Returns 0 if success.
+  */
+-static int sun50i_cpufreq_get_efuse(u32 *versions)
++static int sun50i_cpufreq_get_efuse(const struct sunxi_cpufreq_soc_data *soc_data,
++	u32 *versions)
+ {
+ 	struct nvmem_cell *speedbin_nvmem;
+ 	struct device_node *np;
+ 	struct device *cpu_dev;
+-	u32 *speedbin, efuse_value;
++	u32 *speedbin;
+ 	size_t len;
+-	int ret;
+ 
+ 	cpu_dev = get_cpu_device(0);
+ 	if (!cpu_dev)
+ 		return -ENODEV;
+ 
+ 	np = dev_pm_opp_of_get_opp_desc_node(cpu_dev);
+ 	if (!np)
+ 		return -ENOENT;
+ 
+-	ret = of_device_is_compatible(np,
+-				      "allwinner,sun50i-h6-operating-points");
+-	if (!ret) {
++	if      (of_device_is_compatible(np, "allwinner,sun50i-h6-operating-points")) {}
++	else if	(of_device_is_compatible(np, "allwinner,sun50i-h616-operating-points")) {}
++	else {
+ 		of_node_put(np);
+ 		return -ENOENT;
+ 	}
+ 
+ 	speedbin_nvmem = of_nvmem_cell_get(np, NULL);
+@@ -63,40 +99,35 @@ static int sun50i_cpufreq_get_efuse(u32 *versions)
+ 	speedbin = nvmem_cell_read(speedbin_nvmem, &len);
+ 	nvmem_cell_put(speedbin_nvmem);
+ 	if (IS_ERR(speedbin))
+ 		return PTR_ERR(speedbin);
+ 
+-	efuse_value = (*speedbin >> NVMEM_SHIFT) & NVMEM_MASK;
+-
+-	/*
+-	 * We treat unexpected efuse values as if the SoC was from
+-	 * the slowest bin. Expected efuse values are 1-3, slowest
+-	 * to fastest.
+-	 */
+-	if (efuse_value >= 1 && efuse_value <= 3)
+-		*versions = efuse_value - 1;
+-	else
+-		*versions = 0;
++	*versions = soc_data->efuse_xlate(speedbin);
+ 
+ 	kfree(speedbin);
+ 	return 0;
+ };
+ 
+ static int sun50i_cpufreq_nvmem_probe(struct platform_device *pdev)
+ {
++	const struct of_device_id *match;
+ 	int *opp_tokens;
+ 	char name[MAX_NAME_LEN];
+ 	unsigned int cpu;
+ 	u32 speed = 0;
+ 	int ret;
+ 
++	match = dev_get_platdata(&pdev->dev);
++	if (!match)
++		return -EINVAL;
++
+ 	opp_tokens = kcalloc(num_possible_cpus(), sizeof(*opp_tokens),
+ 			     GFP_KERNEL);
+ 	if (!opp_tokens)
+ 		return -ENOMEM;
+ 
+-	ret = sun50i_cpufreq_get_efuse(&speed);
++	ret = sun50i_cpufreq_get_efuse(match->data, &speed);
+ 	if (ret) {
+ 		kfree(opp_tokens);
+ 		return ret;
+ 	}
+ 
+@@ -158,12 +189,20 @@ static struct platform_driver sun50i_cpufreq_driver = {
+ 	.driver = {
+ 		.name = "sun50i-cpufreq-nvmem",
+ 	},
+ };
+ 
++static const struct sunxi_cpufreq_soc_data sun50i_h616_data = {
++	.efuse_xlate = sun50i_h616_efuse_xlate,
++};
++static const struct sunxi_cpufreq_soc_data sun50i_h6_data = {
++	.efuse_xlate = sun50i_h6_efuse_xlate,
++};
++
+ static const struct of_device_id sun50i_cpufreq_match_list[] = {
+-	{ .compatible = "allwinner,sun50i-h6" },
++	{ .compatible = "allwinner,sun50i-h6", .data = &sun50i_h6_data },
++	{ .compatible = "allwinner,sun50i-h616", .data = &sun50i_h616_data },
+ 	{}
+ };
+ MODULE_DEVICE_TABLE(of, sun50i_cpufreq_match_list);
+ 
+ static const struct of_device_id *sun50i_cpufreq_match_node(void)
+@@ -194,13 +233,13 @@ static int __init sun50i_cpufreq_init(void)
+ 
+ 	ret = platform_driver_register(&sun50i_cpufreq_driver);
+ 	if (unlikely(ret < 0))
+ 		return ret;
+ 
+-	sun50i_cpufreq_pdev =
+-		platform_device_register_simple("sun50i-cpufreq-nvmem",
+-						-1, NULL, 0);
++	sun50i_cpufreq_pdev = platform_device_register_data(NULL,
++		"sun50i-cpufreq-nvmem", -1, match, sizeof(*match));
++
+ 	ret = PTR_ERR_OR_ZERO(sun50i_cpufreq_pdev);
+ 	if (ret == 0)
+ 		return 0;
+ 
+ 	platform_driver_unregister(&sun50i_cpufreq_driver);
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/sunxi-6.2/series.armbian
+++ b/patch/kernel/archive/sunxi-6.2/series.armbian
@@ -106,6 +106,7 @@
 	patches.armbian/arm64-dts-allwinner-h616-Add-device-node-for-SID.patch
 	patches.armbian/arm64-dts-allwinner-h616-Add-thermal-sensor-and-thermal-zones.patch
 	patches.armbian/arm64-dts-allwinner-h616-Fix-thermal-zones-missing-trips.patch
+	patches.armbian/arm64-dts-allwinner-h616-cpu-optimizations.patch
 ###################
 	patches.armbian/arm64-dts-sun50i-a64-pine64-enable-Bluetooth.patch
 	patches.armbian/arm64-dts-sun50i-a64-sopine-baseboard-enable-Bluetooth.patch

--- a/patch/kernel/archive/sunxi-6.2/series.conf
+++ b/patch/kernel/archive/sunxi-6.2/series.conf
@@ -502,6 +502,7 @@
 	patches.armbian/arm64-dts-allwinner-h616-Add-device-node-for-SID.patch
 	patches.armbian/arm64-dts-allwinner-h616-Add-thermal-sensor-and-thermal-zones.patch
 	patches.armbian/arm64-dts-allwinner-h616-Fix-thermal-zones-missing-trips.patch
+	patches.armbian/arm64-dts-allwinner-h616-cpu-optimizations.patch
 ###################
 	patches.armbian/arm64-dts-sun50i-a64-pine64-enable-Bluetooth.patch
 	patches.armbian/arm64-dts-sun50i-a64-sopine-baseboard-enable-Bluetooth.patch


### PR DESCRIPTION
TBD

Most of the work based on this PR made for 5.19 kernel (by [AGM1968](https://github.com/AGM1968)): https://github.com/armbian/build/pull/5123

---

### Benchmarks

Testing environment:

- Debian Bullseye
- Cooled passively using copper heatspreader
- Outside of a case
- Ambient temp: ~25.5℃

Test results:

- Kernel 6.1
  - Before: http://ix.io/4wsG
  - After: http://ix.io/4wtg
- Kernel 6.2
  - Before: http://ix.io/4wsZ
  - After: http://ix.io/4wtu

(some of the test results shown below)

| test | kernel 6.1 (before) | kernel 6.1 (after) | kernel 6.2 (before) | kernel 6.2 (after) |
|--------|--------|--------|--------|--------|
| Cpuminer | 3.74 | 4.39 | 3.73 | 4.38 |
| 7-zip (multi) | 2701 | 3153 | 2713 | 3154 |
| 7-zip (single) | 775 | 1086 | 775 | 1084 |
| memcpy | 1581.5 MB/s | 1697.7 MB/s | 1588.3 MB/s | 1671.9 MB/s | 
| memset | 5307.4 MB/s | 5434.1 MB/s | 5306.9 MB/s | 5434.9 MB/s | 
| OpenSSL (aes-128-cbc / 16 B) | 65358.50k | 91305.81k | 65043.15k | 91367.81k | 

### Summary

- Results are more in line with 4.9 kernel
  - https://github.com/ThomasKaiser/sbc-bench/blob/master/Results.md